### PR TITLE
docs(demo): enable demo

### DIFF
--- a/doc-site/.dumi/app.ts
+++ b/doc-site/.dumi/app.ts
@@ -110,7 +110,6 @@ export default defineConfig({
   "scripts": {
     "dev": "vite",
     "build": "tsc && vite build",
-    "lint": "eslint . --ext ts,tsx --report-unused-disable-directives --max-warnings 0",
     "preview": "vite preview"
   },
   "dependencies": {
@@ -121,12 +120,7 @@ export default defineConfig({
   "devDependencies": {
     "@types/react": "^18.2.66",
     "@types/react-dom": "^18.2.22",
-    "@typescript-eslint/eslint-plugin": "^7.2.0",
-    "@typescript-eslint/parser": "^7.2.0",
     "@vitejs/plugin-react": "^4.2.1",
-    "eslint": "^8.57.0",
-    "eslint-plugin-react-hooks": "^4.6.0",
-    "eslint-plugin-react-refresh": "^0.4.6",
     "typescript": "^5.2.2",
     "esbuild-plugin-react-virtualized": "^1.0.4",
     "postcss": "^8.4.38",
@@ -135,27 +129,7 @@ export default defineConfig({
   }
 }
 `,
-  '.eslintrc.cjs': `
-module.exports = {
-  root: true,
-  env: { browser: true, es2020: true },
-  extends: [
-    'eslint:recommended',
-    'plugin:@typescript-eslint/recommended',
-    'plugin:react-hooks/recommended',
-  ],
-  ignorePatterns: ['dist', '.eslintrc.cjs'],
-  parser: '@typescript-eslint/parser',
-  plugins: ['react-refresh'],
-  rules: {
-    'react-refresh/only-export-components': [
-      'warn',
-      { allowConstantExport: true },
-    ],
-  },
-}
-`,
-'tailwind.config.js': `
+  'tailwind.config.js': `
 module.exports = {
   theme: {},
   variants: {},
@@ -164,11 +138,11 @@ module.exports = {
     './src/**/*.tsx',
   ],
 }`,
-'src/index.css': `
+  'src/index.css': `
   @tailwind components;
   @tailwind utilities;
 `,
-'postcss.config.js': `
+  'postcss.config.js': `
 export default {
   plugins: {
     tailwindcss: {},

--- a/doc-site/.dumi/app.ts
+++ b/doc-site/.dumi/app.ts
@@ -1,14 +1,25 @@
 import { type IPreviewerProps } from 'dumi';
 import { type Project } from '@stackblitz/sdk';
+import { IFiles } from 'codesandbox-import-utils/lib/api/define';
 
 export function modifyStackBlitzData(memo: Project, props: IPreviewerProps) {
   // if use default template: 'create-react-app', demo won't install dependencies automatically
   memo.template = 'node';
+  return createTemplate(memo, props, true);
+}
+
+export function modifyCodeSandboxData(memo: { files: IFiles }, props: IPreviewerProps) {
+  return createTemplate(memo, props, false);
+}
+
+function createTemplate(memo: { files: IFiles } | Project, props: IPreviewerProps, isStackBlitz: boolean) {
   Object.entries(memo.files).forEach(([name, content]) => {
     if (name !== 'index.html' && name !== 'package.json') {
       memo.files[`src/${name}`] = content;
     }
-    delete memo.files[name];
+    if (name !== 'sandbox.config.json') {
+      delete memo.files[name];
+    }
   });
   Object.entries(template).forEach(([name, content]) => {
     if (name === 'package.json') {
@@ -22,7 +33,7 @@ export function modifyStackBlitzData(memo: Project, props: IPreviewerProps) {
       packageJson.dependencies = { ...npmDeps, ...packageJson.dependencies };
       content = JSON.stringify(packageJson, null, 2);
     }
-    memo.files[name] = content;
+    memo.files[name] = isStackBlitz ? content : { content: content, isBinary: false };
   });
 
   return memo;

--- a/doc-site/.dumi/app.ts
+++ b/doc-site/.dumi/app.ts
@@ -1,0 +1,146 @@
+import { type IPreviewerProps } from 'dumi';
+import { type Project } from '@stackblitz/sdk';
+
+export function modifyStackBlitzData(memo: Project, props: IPreviewerProps) {
+  // if use default template: 'create-react-app', demo won't install dependencies automatically
+  memo.template = 'node';
+  Object.entries(memo.files).forEach(([name, content]) => {
+    if (name !== 'index.html' && name !== 'package.json') {
+      memo.files[`src/${name}`] = content;
+    }
+    delete memo.files[name];
+  });
+  Object.entries(template).forEach(([name, content]) => {
+    if (name === 'package.json') {
+      const packageJson = JSON.parse(content);
+      const npmDeps = Object.entries(props.asset.dependencies || {})
+        .filter(([key, value]) => value.type === 'NPM')
+        .reduce((acc: { [key: string]: any }, [key, value]) => {
+          acc[key] = value.value;
+          return acc;
+        }, {});
+      packageJson.dependencies = { ...npmDeps, ...packageJson.dependencies };
+      content = JSON.stringify(packageJson, null, 2);
+    }
+    memo.files[name] = content;
+  });
+
+  return memo;
+}
+
+const template = {
+  'tsconfig.json': `
+{
+  "compilerOptions": {
+    "target": "ES2020",
+    "useDefineForClassFields": true,
+    "lib": ["ES2020", "DOM", "DOM.Iterable"],
+    "module": "ESNext",
+    "skipLibCheck": true,
+
+    /* Bundler mode */
+    "moduleResolution": "bundler",
+    "allowImportingTsExtensions": true,
+    "resolveJsonModule": true,
+    "isolatedModules": true,
+    "noEmit": true,
+    "jsx": "react-jsx",
+
+    /* Linting */
+    "strict": true,
+    "noUnusedLocals": true,
+    "noUnusedParameters": true,
+    "noFallthroughCasesInSwitch": true
+  },
+  "include": ["src"],
+  "references": [{ "path": "./tsconfig.node.json" }]
+}
+`,
+  'tsconfig.node.json': `
+{
+  "compilerOptions": {
+    "composite": true,
+    "skipLibCheck": true,
+    "module": "ESNext",
+    "moduleResolution": "bundler",
+    "allowSyntheticDefaultImports": true,
+    "strict": true
+  },
+  "include": ["vite.config.ts"]
+}
+`,
+  'vite.config.ts': `
+import { defineConfig } from 'vite';
+import react from '@vitejs/plugin-react';
+
+// https://vitejs.dev/config/
+export default defineConfig({
+  plugins: [react()],
+});
+`,
+  'index.html': `
+<!doctype html>
+<html lang="en">
+  <head>
+    <meta charset="UTF-8" />
+    <link rel="icon" type="image/svg+xml" href="/vite.svg" />
+    <meta name="viewport" content="width=device-width, initial-scale=1.0" />
+    <title>Vite + React + TS</title>
+  </head>
+  <body>
+    <div id="root"></div>
+    <script type="module" src="/src/index.tsx"></script>
+  </body>
+</html>
+`,
+  'package.json': `
+{
+  "name": "An auto-generated demo by dumi",
+  "private": true,
+  "version": "0.0.0",
+  "type": "module",
+  "scripts": {
+    "dev": "vite",
+    "build": "tsc && vite build",
+    "lint": "eslint . --ext ts,tsx --report-unused-disable-directives --max-warnings 0",
+    "preview": "vite preview"
+  },
+  "dependencies": {
+    "react": "^18.2.0",
+    "react-dom": "^18.2.0"
+  },
+  "devDependencies": {
+    "@types/react": "^18.2.66",
+    "@types/react-dom": "^18.2.22",
+    "@typescript-eslint/eslint-plugin": "^7.2.0",
+    "@typescript-eslint/parser": "^7.2.0",
+    "@vitejs/plugin-react": "^4.2.1",
+    "eslint": "^8.57.0",
+    "eslint-plugin-react-hooks": "^4.6.0",
+    "eslint-plugin-react-refresh": "^0.4.6",
+    "typescript": "^5.2.2",
+    "vite": "^5.2.0"
+  }
+}
+`,
+  '.eslintrc.cjs': `
+module.exports = {
+  root: true,
+  env: { browser: true, es2020: true },
+  extends: [
+    'eslint:recommended',
+    'plugin:@typescript-eslint/recommended',
+    'plugin:react-hooks/recommended',
+  ],
+  ignorePatterns: ['dist', '.eslintrc.cjs'],
+  parser: '@typescript-eslint/parser',
+  plugins: ['react-refresh'],
+  rules: {
+    'react-refresh/only-export-components': [
+      'warn',
+      { allowConstantExport: true },
+    ],
+  },
+}
+`
+}

--- a/doc-site/.dumi/app.ts
+++ b/doc-site/.dumi/app.ts
@@ -14,12 +14,20 @@ export function modifyCodeSandboxData(memo: { files: IFiles }, props: IPreviewer
 
 function createTemplate(memo: { files: IFiles } | Project, props: IPreviewerProps, isStackBlitz: boolean) {
   Object.entries(memo.files).forEach(([name, content]) => {
+    if (name === 'sandbox.config.json') {
+      memo.files[name] = {
+        content: JSON.stringify({
+          template: 'node',
+          startScript: 'dev',
+        }, null, 2),
+        isBinary: false,
+      };
+      return;
+    }
     if (name !== 'index.html' && name !== 'package.json') {
       memo.files[`src/${name}`] = content;
     }
-    if (name !== 'sandbox.config.json') {
-      delete memo.files[name];
-    }
+    delete memo.files[name];
   });
   Object.entries(template).forEach(([name, content]) => {
     if (name === 'package.json') {
@@ -114,7 +122,7 @@ export default defineConfig({
 `,
   'package.json': `
 {
-  "name": "An auto-generated demo by dumi",
+  "name": "demo",
   "private": true,
   "version": "0.0.0",
   "type": "module",

--- a/doc-site/.dumi/theme/builtins/Previewer.tsx
+++ b/doc-site/.dumi/theme/builtins/Previewer.tsx
@@ -1,5 +1,5 @@
 // @ts-nocheck
 import Previewer from 'dumi/theme-default/builtins/Previewer';
 export default (props) => {
-  return <Previewer {...props} />;
+  return <Previewer {...props} disabledActions={['CSB']} />;
 };

--- a/doc-site/.dumi/theme/builtins/Previewer.tsx
+++ b/doc-site/.dumi/theme/builtins/Previewer.tsx
@@ -1,5 +1,5 @@
 // @ts-nocheck
 import Previewer from 'dumi/theme-default/builtins/Previewer';
 export default (props) => {
-  return <Previewer {...props} disabledActions={['CSB', 'STACKBLITZ']} />;
+  return <Previewer {...props} />;
 };

--- a/doc-site/docs/demo/utils.ts
+++ b/doc-site/docs/demo/utils.ts
@@ -1,18 +1,25 @@
+const BASE_URL = 'https://bilibili.github.io/WebAV';
 export function assetsPrefix<T extends string[] | Record<string, string>>(
-  assetsURL: T
+  assetsURL: T,
 ): T {
+  const base =
+    window.location.hostname.includes('webcontainer.io') ||
+    window.location.hostname.includes('stackblitz.io') ||
+    window.location.hostname.includes('csb.app')
+      ? BASE_URL
+      : '';
   const prefix = process.env.NODE_ENV === 'development' ? '/' : '/WebAV/';
   if (Array.isArray(assetsURL)) {
-    return assetsURL.map((url) => `${prefix}${url}`) as T;
+    return assetsURL.map((url) => `${base}${prefix}${url}`) as T;
   }
 
   return Object.fromEntries(
-    Object.entries(assetsURL).map(([k, v]) => [k, `${prefix}${v}`])
+    Object.entries(assetsURL).map(([k, v]) => [k, `${base}${prefix}${v}`]),
   ) as T;
 }
 
 export async function createFileWriter(
-  extName = 'mp4'
+  extName = 'mp4',
 ): Promise<FileSystemWritableFileStream> {
   const fileHandle = await window.showSaveFilePicker({
     suggestedName: `WebAV-export-${Date.now()}.${extName}`,

--- a/packages/av-cliper/src/mp4-utils/index.ts
+++ b/packages/av-cliper/src/mp4-utils/index.ts
@@ -491,7 +491,6 @@ async function concatStreamsToMP4BoxFile(
   let lastASamp: any = null;
   for (const stream of streams) {
     await new Promise<void>(async (resolve) => {
-      let curFile: MP4File | null = null;
       autoReadStream(stream.pipeThrough(new SampleTransform()), {
         onDone: resolve,
         onChunk: async ({ chunkType, data }) => {
@@ -500,7 +499,6 @@ async function concatStreamsToMP4BoxFile(
               data.file,
               data.info,
             );
-            curFile = data.file;
             if (vTrackId === 0 && videoTrackConf != null) {
               vTrackId = outfile.addTrack(videoTrackConf);
             }


### PR DESCRIPTION
## 背景：
dumi 是支持自动分析demo依赖，然后在 codesandbox stackblitz 打开，之前这个功能是被关闭了。

## 改动：
* 打开对应功能，因为demo中涉及音视频文件，又不支持导入媒体文件，所以在检测到在沙盒打开时使用GitHub pages的资源。
* 在打开 stackblitz 使用模板原本为 `create-react-app`，此时除了 react、react-dom依赖，都不会自动安装，所以改为了 `node` 模板，并且改进了目录结构，dumi生成的结构和依赖比较简单

## 测试：
1. 
- 视频配音
- 音频合成
- 嵌入字幕
- 合成再拼接
- 自定义素材
这些demo中，因为dumi分析依赖时，缺少了 antd 依赖，打开后无法直接使用，需要手动安装依赖，安装后成功运行  

2.
视频剪辑demo，stackblitz 打开失败