### PR TITLE
Feature/support playback rate for single sprite in av-canvas

### DIFF
--- a/packages/av-canvas/demo/video-editor.tsx
+++ b/packages/av-canvas/demo/video-editor.tsx
@@ -232,9 +232,18 @@ function App() {
       <button
         className="mx-[10px]"
         onClick={async () => {
-          const spr = new VisibleSprite(
-            new MP4Clip((await fetch('./video/bunny_0.mp4')).body!),
-          );
+          let clip = new MP4Clip((await fetch('./video/bunny_0.mp4')).body!);
+          clip.tickInterceptor = async (
+            _,
+            tickRet: ReturnType<MP4Clip['tick']>,
+          ) => {
+            if (tickRet.video == null) return tickRet;
+            // 可在此处对视频帧或音频数据进行处理
+            return {
+              ...tickRet,
+            };
+          };
+          const spr = new VisibleSprite(clip);
           await avCvs?.addSprite(spr);
           addSprite2Track('1-video', spr, '视频');
         }}

--- a/packages/av-canvas/demo/video-editor.tsx
+++ b/packages/av-canvas/demo/video-editor.tsx
@@ -234,7 +234,7 @@ function App() {
         onClick={async () => {
           let clip = new MP4Clip((await fetch('./video/bunny_0.mp4')).body!);
           clip.tickInterceptor = async (
-            _,
+            _: number,
             tickRet: ReturnType<MP4Clip['tick']>,
           ) => {
             if (tickRet.video == null) return tickRet;

--- a/packages/av-canvas/src/types.ts
+++ b/packages/av-canvas/src/types.ts
@@ -21,3 +21,26 @@ export interface ICvsRatio {
   w: number;
   h: number;
 }
+
+/**
+ * 音频配置参数
+ */
+interface AudioConfig {
+  playbackRate: number;
+}
+
+/**
+ * 音频结构参数
+ */
+export interface AudiosSchema {
+  pcmData: Float32Array[];
+  audioConfig: AudioConfig;
+}
+
+/**
+ * 音频播放源结构参数
+ */
+export interface AudioSourceSchema {
+  audioSource: AudioBufferSourceNode;
+  audioConfig: AudioConfig;
+}

--- a/packages/av-cliper/src/sprite/base-sprite.ts
+++ b/packages/av-cliper/src/sprite/base-sprite.ts
@@ -28,13 +28,23 @@ export abstract class BaseSprite {
   rect = new Rect();
 
   /**
-   * 控制素材在视频中的时间偏移与时长，常用于剪辑场景时间轴（轨道）模块
+   * 控制素材在视频中的时间偏移、时长与播放速率，常用于剪辑场景时间轴（轨道）模块
    *
    * duration 不能大于引用 {@link IClip} 的时长，单位 微秒
+   * playbackRate - 播放速率。1 表示正常速度，2 表示两倍速度，0.5 表示半速等。如果未指定，则默认为 1
    */
   time = {
     offset: 0,
     duration: 0,
+    _playbackRate: 1,
+    get playbackRate() {
+      return this._playbackRate;
+    },
+    set playbackRate(v: number) {
+      if (v < 0) throw Error('playbackRate must > 0');
+      this._playbackRate = v;
+      this.duration = this.duration / v;
+    },
   };
 
   /**

--- a/packages/av-cliper/src/sprite/visible-sprite.ts
+++ b/packages/av-cliper/src/sprite/visible-sprite.ts
@@ -14,6 +14,7 @@ import { Log } from '../log';
  * spr.opacity = 0.5 // 半透明
  * spr.rect.x = 100 // x 坐标偏移 100 像素
  * spr.time.offset = 10e6 // 视频第 10s 开始绘制素材
+ * spr.time.playbackRate = 2 // 双倍速播放
  *
  * @see [视频剪辑](https://bilibili.github.io/WebAV/demo/6_4-video-editor)
  *
@@ -31,7 +32,9 @@ export class VisibleSprite extends BaseSprite {
       this.rect.w = this.rect.w === 0 ? width : this.rect.w;
       this.rect.h = this.rect.h === 0 ? height : this.rect.h;
       this.time.duration =
-        this.time.duration === 0 ? duration : this.time.duration;
+        this.time.duration === 0
+          ? duration / this.time.playbackRate
+          : this.time.duration / this.time.playbackRate;
     });
   }
 
@@ -75,7 +78,8 @@ export class VisibleSprite extends BaseSprite {
     this.animate(time);
     super._render(ctx);
     const { w, h } = this.rect;
-    if (this.#lastTime !== time) this.#update(time);
+    const { playbackRate = 1 } = this.time;
+    if (this.#lastTime !== time) this.#update(time * playbackRate);
     this.#lastTime = time;
 
     const audio = this.#lastAudio;


### PR DESCRIPTION
Fixes #200 
为base-sprite的time结构中添加playbackRate属性来控制单个sprite的播放速率，在av-canvas的音频处理过程中添加播放速率的配置，使得av-canvas具备倍速播放的能力。
在video-editor中添加tickInterceptor示例代码，可在该处获取音视频数据并做调整。
![image](https://github.com/user-attachments/assets/a7ec9931-d0af-466f-b882-43f7f5822fc9)
