### PR TITLE
fix: update this.#decoding when call reset function

### DIFF
--- a/packages/av-cliper/src/clips/mp4-clip.ts
+++ b/packages/av-cliper/src/clips/mp4-clip.ts
@@ -740,6 +740,7 @@ class VideoFrameFinder {
         ? { hardwareAcceleration: 'prefer-software' }
         : {}),
     });
+    this.#decoding = false;
   };
 
   #getState = () => ({


### PR DESCRIPTION
Closes #236
当连续 tick 时（反向拖动预览进度条）会进入 reset 方法（`time <= this.#ts`）
```ts
    if (this.#dec == null || time <= this.#ts || time - this.#ts > 3e6) {
      this.reset(time);
    }
```
然后会触发 `this.#dec?.close()` 导致 `startDecode` 方法中因为 `if (dec.state === 'closed') return;` 被提前返回，此时 `this.#decoding` 依然为 `true`（正常来说 `startDecode` 中会完成 `this.#decoding` 由 `true` 到 `false` 的更新）。然后会在 `parseFrame` 接口中由于 `this.#decoding` 为 `true` 导致 `MP4Clip.tick video timeout` 的错误被抛出。

所以，这个 PR 会在 `reset` 时将 `this.#decoding` 设置为 `false`。