### PR TITLE
fix: preFirstFrame when VisibleSprite is ready

### DIFF
--- a/packages/av-cliper/src/sprite/visible-sprite.ts
+++ b/packages/av-cliper/src/sprite/visible-sprite.ts
@@ -32,6 +32,7 @@ export class VisibleSprite extends BaseSprite {
       this.rect.h = this.rect.h === 0 ? height : this.rect.h;
       this.time.duration =
         this.time.duration === 0 ? duration : this.time.duration;
+      this.preFrame(0);
     });
   }
 


### PR DESCRIPTION
添加VisibleSprite时ready后获取首帧，避免视频分割等操作后offset不为0时首帧异常。
#245 