### PR TITLE
fix: other types of isIDRFrame judgments

### DIFF
--- a/.changeset/clean-rules-care.md
+++ b/.changeset/clean-rules-care.md
@@ -1,0 +1,5 @@
+---
+"@webav/av-cliper": patch
+---
+
+fix: other types of isIDRFrame judgments

--- a/packages/av-cliper/src/clips/mp4-clip.ts
+++ b/packages/av-cliper/src/clips/mp4-clip.ts
@@ -1208,7 +1208,7 @@ function removeSEIForIDR(u8buf: Uint8Array) {
 }
 
 function isIDRFrame(u8Arr: Uint8Array, type: MP4Sample['description']['type']) {
-  if (type !== 'avc1' && type !== 'hvc1') return false;
+  if (type !== 'avc1' && type !== 'hvc1') return true;
 
   const dv = new DataView(u8Arr.buffer);
   let i = 0;


### PR DESCRIPTION
 if (type !== 'avc1' && type !== 'hvc1') return false;   ==>  if (type !== 'avc1' && type !== 'hvc1') return true;