### PR TITLE
Auto build @webav/internal-utils

### DIFF
--- a/.changeset/spicy-lamps-tell.md
+++ b/.changeset/spicy-lamps-tell.md
@@ -1,0 +1,6 @@
+---
+'@webav/internal-utils': patch
+'@webav/av-cliper': patch
+---
+
+chore: replace prepublishOnly with prepare scripts to auto build @webav/av-cliper and @webav/internal-utils

--- a/packages/av-cliper/package.json
+++ b/packages/av-cliper/package.json
@@ -34,7 +34,7 @@
     "build:dev": "vite build --watch",
     "build:api": "typedoc src/index.ts --out ../../doc-site/public/_api/av-cliper",
     "build:api:watch": "typedoc src/index.ts --out ../../doc-site/public/_api/av-cliper --watch",
-    "prepublishOnly": "pnpm build"
+    "prepare": "pnpm build"
   },
   "files": [
     "dist"

--- a/packages/internal-utils/package.json
+++ b/packages/internal-utils/package.json
@@ -19,7 +19,7 @@
     "ci:test": "vitest run",
     "build": "vite build",
     "build:dev": "vite build --watch",
-    "prepublishOnly": "pnpm build"
+    "prepare": "pnpm build"
   },
   "dependencies": {
     "@webav/mp4box.js": "0.5.4-fenghen"


### PR DESCRIPTION
chore: add prepare and prepack scripts to auto build @webav/internal-utils

prepublishOnly: 仅在 npm publish 之前运行
prepare: 在包被安装为依赖时运行(包括开发安装)，以及 npm publish 之前运行
prepack: 在包被打包时运行(如 npm pack)，以及 npm publish 之前运行