### PR TITLE
Feat: add new event renderTime to combinator while output

### DIFF
--- a/.changeset/shy-baboons-impress.md
+++ b/.changeset/shy-baboons-impress.md
@@ -1,0 +1,5 @@
+---
+'@webav/av-cliper': patch
+---
+
+feat: add new event renderTime to combinator while ouput

--- a/packages/av-cliper/src/combinator.ts
+++ b/packages/av-cliper/src/combinator.ts
@@ -117,6 +117,7 @@ export class Combinator {
   #hasVideoTrack: boolean;
 
   #evtTool = new EventTool<{
+    renderTime: (time: number) => void;
     OutputProgress: (progress: number) => void;
     error: (err: Error) => void;
   }>();
@@ -329,6 +330,9 @@ export class Combinator {
           await onEnded();
           return;
         }
+
+        this.#evtTool.emit('renderTime', ts);
+
         progress = ts / maxTime;
 
         const { audios, mainSprDone } = await sprRender(ts);


### PR DESCRIPTION
使用场景为av-canvas在createCombinator时如果有tickInterceptor处理音视频，且这个过程中需要使用到当前渲染时间，在av-canvas外部是无法获取的，因此需要在combinator中增加一个渲染时间的事件通知。